### PR TITLE
Stop multiplying UV index in hourly forecast by 100

### DIFF
--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -197,7 +197,7 @@ def _map_hourly_forecast(forecast: dict[str, Any]) -> Forecast:
         "native_precipitation": round(forecast.d.get("precipIntensity"), 2),
         "precipitation_probability":round(forecast.d.get("precipProbability")*100, 0),
         "cloud_coverage":  round(forecast.d.get("cloudCover")*100, 0), 
-        "uv_index":  round(forecast.d.get("uvIndex")*100, 0), 
+        "uv_index":  round(forecast.d.get("uvIndex"), 2), 
     }             
 
 async def async_setup_entry(


### PR DESCRIPTION
Fixes #155

Also ensures rounding is to 2 decimal places, as the API seems to return data with that precision.

Have tested by tweaking HACS clone in local HA, and confirmed that the number looks more sensible and similar to other forecasts.

