### PR TITLE
Fix Precipitation Accumulation Units

### DIFF
--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -972,12 +972,12 @@ class PirateWeatherSensor(SensorEntity):
           ]:
               state = ((state * 9 / 5) + 32)
 
-        # Precipitation Accumilation (cm in SI) to inches 
+        # Precipitation Accumilation (mm in SI) to inches 
         if self.requestUnits in ["us"]:
           if self.type in [
               "precip_accumulation", 
           ]:
-              state = (state * 0.393701)
+              state = (state * 0.0393701)
               
         # Precipitation Intensity (mm/h in SI) to inches 
         if self.requestUnits in ["us"]:

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -174,7 +174,7 @@ def _map_daily_forecast(forecast) -> Forecast:
         "condition": MAP_CONDITION.get(forecast.d.get("icon")),
         "native_temperature": forecast.d.get("temperatureHigh"),
         "native_templow": forecast.d.get("temperatureLow"),
-        "native_precipitation": forecast.d.get("precipAccumulation")*10*10,
+        "native_precipitation": forecast.d.get("precipAccumulation")*10,
         "precipitation_probability":  round(forecast.d.get("precipProbability")*100, 0),
         "humidity": round(forecast.d.get("humidity")*100, 2),
         "cloud_coverage":  round(forecast.d.get("cloudCover")*100, 0),


### PR DESCRIPTION
When `precipAccumulation` was changed from cm to mm in #122 the conversion was never changed to convert from mm to inches. This PR changes the conversion and fixes #166

~Is precipAccumulation on hourly in mm or cm? If it's cm then we need to convert it to mm otherwise the conversion on hourly will be incorrect.~ Edit: Looked at the code and it's using a different variable.