### PR TITLE
Replace rounding option with suggested_display_precision

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,7 +2,7 @@
 
 target-version = "py310"
 
-select = [
+lint.select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
     "C",  # complexity
@@ -26,7 +26,7 @@ select = [
     "W",  # pycodestyle
 ]
 
-ignore = [
+lint.ignore = [
     "D202",  # No blank lines allowed after function docstring
     "D203",  # 1 blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
@@ -57,11 +57,11 @@ ignore = [
     "PLE0605",
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/custom_components/pirateweather/__init__.py
+++ b/custom_components/pirateweather/__init__.py
@@ -30,7 +30,6 @@ from .const import (
     CONF_UNITS,
     PW_PLATFORMS,
     PW_PLATFORM,
-    PW_ROUND,
 )
 
 # from .weather_update_coordinator import WeatherUpdateCoordinator, DarkSkyData
@@ -55,7 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     forecast_days = _get_config_value(entry, CONF_FORECAST)
     forecast_hours = _get_config_value(entry, CONF_HOURLY_FORECAST)
     pw_entity_platform = _get_config_value(entry, PW_PLATFORM)
-    pw_entity_rounding = _get_config_value(entry, PW_ROUND)
     pw_scan_Int = entry.data[CONF_SCAN_INTERVAL]
 
     # Extract list of int from forecast days/ hours string if present
@@ -108,7 +106,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_FORECAST: forecast_days,
         CONF_HOURLY_FORECAST: forecast_hours,
         PW_PLATFORM: pw_entity_platform,
-        PW_ROUND: pw_entity_rounding,
         CONF_SCAN_INTERVAL: pw_scan_Int,
     }
 

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -34,7 +34,6 @@ from .const import (
     PW_PLATFORMS,
     PW_PLATFORM,
     PW_PREVPLATFORM,
-    PW_ROUND,
 )
 
 ATTRIBUTION = "Powered by Pirate Weather"
@@ -84,7 +83,6 @@ class PirateWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_MONITORED_CONDITIONS, default=[]): cv.multi_select(
                     ALL_CONDITIONS
                 ),
-                vol.Optional(PW_ROUND, default="No"): vol.In(["Yes", "No"]),
                 vol.Optional(CONF_UNITS, default=DEFAULT_UNITS): vol.In(
                     ["si", "us", "ca", "uk"]
                 ),
@@ -172,8 +170,6 @@ class PirateWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             config[PW_PLATFORM] = None
         if PW_PREVPLATFORM not in config:
             config[PW_PREVPLATFORM] = None
-        if PW_ROUND not in config:
-            config[PW_ROUND] = "No"
         if CONF_SCAN_INTERVAL not in config:
             config[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
         return await self.async_step_user(config)
@@ -282,13 +278,6 @@ class PirateWeatherOptionsFlow(config_entries.OptionsFlow):
                             self.config_entry.data.get(CONF_UNITS, DEFAULT_UNITS),
                         ),
                     ): vol.In(["si", "us", "ca", "uk"]),
-                    vol.Optional(
-                        PW_ROUND,
-                        default=self.config_entry.options.get(
-                            PW_ROUND,
-                            self.config_entry.data.get(PW_ROUND, "No"),
-                        ),
-                    ): vol.In(["Yes", "No"]),
                 }
             ),
         )

--- a/custom_components/pirateweather/const.py
+++ b/custom_components/pirateweather/const.py
@@ -61,7 +61,6 @@ PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 PW_PLATFORMS = ["Sensor", "Weather"]
 PW_PLATFORM = "pw_platform"
 PW_PREVPLATFORM = "pw_prevplatform"
-PW_ROUND = "pw_round"
 
 ATTR_FORECAST_CLOUD_COVERAGE = "cloud_coverage"
 ATTR_FORECAST_HUMIDITY = "humidity"

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -50,7 +50,6 @@ from .const import (
     PW_PLATFORMS,
     PW_PLATFORM,
     PW_PREVPLATFORM,
-    PW_ROUND,
 )
 
 
@@ -162,6 +161,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk2_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+        suggested_display_precision=4,
         icon="mdi:weather-rainy",
         forecast_mode=["currently", "minutely", "hourly", "daily"],
     ),
@@ -173,6 +173,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         icon="mdi:water-percent",
         forecast_mode=["currently", "minutely", "hourly", "daily"],
     ),
@@ -185,6 +186,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfLength.CENTIMETERS,
         uk_unit=UnitOfLength.CENTIMETERS,
         uk2_unit=UnitOfLength.CENTIMETERS,
+        suggested_display_precision=4,
         icon="mdi:weather-snowy",
         forecast_mode=["hourly", "daily"],
     ),
@@ -198,6 +200,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly"],
     ),
     "apparent_temperature": PirateWeatherSensorEntityDescription(
@@ -210,6 +213,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly"],
     ),
     "dew_point": PirateWeatherSensorEntityDescription(
@@ -222,6 +226,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "wind_speed": PirateWeatherSensorEntityDescription(
@@ -233,6 +238,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
         uk_unit=UnitOfSpeed.MILES_PER_HOUR,
         uk2_unit=UnitOfSpeed.MILES_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:weather-windy",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -244,6 +250,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=DEGREE,
         uk_unit=DEGREE,
         uk2_unit=DEGREE,
+        suggested_display_precision=0,
         icon="mdi:compass",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -256,6 +263,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
         uk_unit=UnitOfSpeed.MILES_PER_HOUR,
         uk2_unit=UnitOfSpeed.MILES_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:weather-windy-variant",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -267,6 +275,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         icon="mdi:weather-partly-cloudy",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -280,6 +289,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "pressure": PirateWeatherSensorEntityDescription(
@@ -292,6 +302,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfPressure.MBAR,
         uk_unit=UnitOfPressure.MBAR,
         uk2_unit=UnitOfPressure.MBAR,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "visibility": PirateWeatherSensorEntityDescription(
@@ -302,6 +313,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfLength.KILOMETERS,
         uk_unit=UnitOfLength.KILOMETERS,
         uk2_unit=UnitOfLength.MILES,
+        suggested_display_precision=2,
         icon="mdi:eye",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -314,6 +326,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit="DU",
         uk_unit="DU",
         uk2_unit="DU",
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "apparent_temperature_max": PirateWeatherSensorEntityDescription(
@@ -325,6 +338,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_high": PirateWeatherSensorEntityDescription(
@@ -336,6 +350,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_min": PirateWeatherSensorEntityDescription(
@@ -347,6 +362,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_low": PirateWeatherSensorEntityDescription(
@@ -358,6 +374,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_max": PirateWeatherSensorEntityDescription(
@@ -369,6 +386,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_high": PirateWeatherSensorEntityDescription(
@@ -380,6 +398,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_min": PirateWeatherSensorEntityDescription(
@@ -391,6 +410,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_low": PirateWeatherSensorEntityDescription(
@@ -402,6 +422,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "precip_intensity_max": PirateWeatherSensorEntityDescription(
@@ -412,6 +433,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk2_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:thermometer",
         forecast_mode=["daily"],
     ),
@@ -423,6 +445,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UV_INDEX,
         uk_unit=UV_INDEX,
         uk2_unit=UV_INDEX,
+        suggested_display_precision=2,
         icon="mdi:weather-sunny",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -430,6 +453,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         key="moon_phase",
         name="Moon Phase",
         icon="mdi:weather-night",
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "sunrise_time": PirateWeatherSensorEntityDescription(
@@ -613,9 +637,6 @@ async def async_setup_platform(
     # Define as a sensor platform
     config_entry[PW_PLATFORM] = [PW_PLATFORMS[0]]
 
-    # Set as no rounding for compatability
-    config_entry[PW_ROUND] = "No"
-
     hass.async_create_task(
         hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=config_entry
@@ -637,9 +658,6 @@ async def async_setup_entry(
     conditions = domain_data[CONF_MONITORED_CONDITIONS]
     forecast_days = domain_data[CONF_FORECAST]
     forecast_hours = domain_data[CONF_HOURLY_FORECAST]
-
-    # Round Output
-    outputRound = domain_data[PW_ROUND]
 
     sensors: list[PirateWeatherSensor] = []
 
@@ -667,7 +685,6 @@ async def async_setup_entry(
                     forecast_hour=None,
                     description=sensorDescription,
                     requestUnits=requestUnits,
-                    outputRound=outputRound,
                 )
             )
 
@@ -686,7 +703,6 @@ async def async_setup_entry(
                         forecast_hour=None,
                         description=sensorDescription,
                         requestUnits=requestUnits,
-                        outputRound=outputRound,
                     )
                 )
 
@@ -705,7 +721,6 @@ async def async_setup_entry(
                         forecast_hour=int(forecast_h),
                         description=sensorDescription,
                         requestUnits=requestUnits,
-                        outputRound=outputRound,
                     )
                 )
 
@@ -729,7 +744,6 @@ class PirateWeatherSensor(SensorEntity):
         forecast_hour: int,
         description: PirateWeatherSensorEntityDescription,
         requestUnits: str,
-        outputRound: str,
     ) -> None:
         """Initialize the sensor."""
         self.client_name = name
@@ -753,7 +767,6 @@ class PirateWeatherSensor(SensorEntity):
         self.forecast_day = forecast_day
         self.forecast_hour = forecast_hour
         self.requestUnits = requestUnits
-        self.outputRound = outputRound
         self.type = condition
         self._icon = None
         self._alerts = None
@@ -913,19 +926,10 @@ class PirateWeatherSensor(SensorEntity):
         if "summary" in self.type:
             self._icon = getattr(data, "icon", "")
 
-        # If output rounding is requested, round to nearest integer
-        if self.outputRound == "Yes":
-            roundingVal = 0
-        else:
-            roundingVal = 1
-
         # Some state data needs to be rounded to whole values or converted to
         # percentages
         if self.type in ["precip_probability", "cloud_cover", "humidity"]:
-            if roundingVal == 0:
-                state = int(round(state * 100, roundingVal))
-            else:
-                state = round(state * 100, roundingVal)
+            state = state * 100
 
         # Logic to convert from SI to requsested units for compatability
         # Temps in F
@@ -998,12 +1002,6 @@ class PirateWeatherSensor(SensorEntity):
             "wind_speed",
             "wind_gust",
         ]:
-            if roundingVal == 0:
-                outState = int(round(state, roundingVal))
-            else:
-                outState = round(state, roundingVal)
-
-        else:
             outState = state
 
         return outState

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -982,29 +982,8 @@ class PirateWeatherSensor(SensorEntity):
                 "wind_gust",
             ]:
                 state = state * 3.6
-
-        if self.type in [
-            "dew_point",
-            "temperature",
-            "apparent_temperature",
-            "temperature_low",
-            "apparent_temperature_low",
-            "temperature_min",
-            "apparent_temperature_min",
-            "temperature_high",
-            "apparent_temperature_high",
-            "temperature_max",
-            "apparent_temperature_max",
-            "precip_accumulation",
-            "pressure",
-            "ozone",
-            "uvIndex",
-            "wind_speed",
-            "wind_gust",
-        ]:
-            outState = state
-
-        return outState
+                
+        return state
 
     async def async_added_to_hass(self) -> None:
         """Connect to dispatcher listening for entity data notifications."""

--- a/custom_components/pirateweather/translations/cs.json
+++ b/custom_components/pirateweather/translations/cs.json
@@ -21,7 +21,6 @@
                     "hourly_forecast":  "Hodinové předpovědi senzorů ve formátu csv od 0 do 168 (např. '0,1,10'). Používá se pouze pokud jsou požadovány senzory.",
                     "monitored_conditions": "Monitorované podmínky pro vytváření senzorů. Používá se pouze pokud jsou požadovány senzory.",
                     "pw_platform": "Entita počasí a/nebo entita senzoru. Senzor vytvoří entity pro každou podmínku v každém čase. Pokud si nejste jisti, vyberte pouze Počasí!",
-                    "pw_round": "Zaokrouhlit hodnoty na nejbližší celé číslo. Ujistěte se, že vybrané jednotky odpovídají systémovým jednotkám.",
                     "scan_interval": "Sekundy čekání mezi aktualizacemi. Snížení této hodnoty pod 900 sekund (15 minut) se nedoporučuje."                                         
                 },
                 "description": "Nastavte integraci Pirate Weather. Pro generování API klíče jděte na https://pirateweather.net",

--- a/custom_components/pirateweather/translations/en.json
+++ b/custom_components/pirateweather/translations/en.json
@@ -21,7 +21,6 @@
                     "hourly_forecast":  "Hourly forecast sensors in csv form from 0-168 (ex. '0,1,10'). Only used if sensors are requested.",
                     "monitored_conditions": "Monitored conditions to create sensors for. Only used if sensors are requested.",
                     "pw_platform": "Weather Entity and/or Sensor Entity. Sensor will create entities for each condition at each time. If unsure, only select Weather!",
-                    "pw_round": "Round values to the nearest integer. Ensure that the selected units match the system units.",
                     "scan_interval": "Seconds to wait between updates. Reducing this below 900 seconds (15 minutes) is not recomended."                                         
                 },
                 "description": "Set up Pirate Weather integration. To generate API key go to https://pirateweather.net",

--- a/custom_components/pirateweather/translations/nl.json
+++ b/custom_components/pirateweather/translations/nl.json
@@ -21,7 +21,6 @@
                     "hourly_forecast":  "Uurlijkse prognoses sensoren in csv-vorm van 0-168 (bijv. '0,1,10'). Wordt alleen gebruikt als sensoren worden aangeroepen.",
                     "monitored_conditions": "Gecontroleerde omstandigheden om sensoren voor te creëren. Wordt alleen gebruikt als sensoren worden aangeroepen.",
                     "pw_platform": "Weer Entiteit en/of Sensor Entiteit. Sensor maakt op elk moment entiteiten voor elke voorwaarde. Als u het niet zeker weet, selecteert u alleen Weer!",
-                    "pw_round": "Rond waarden af ​​op het dichtstbijzijnde gehele getal. Zorg ervoor dat de geselecteerde eenheden overeenkomen met de systeemeenheden.",
                     "scan_interval": "Seconden wachten tussen updates. Het wordt niet aanbevolen om dit onder de 900 seconden (15 minuten) te zetten."                                         
                 },
                 "description": "Stel Pirate Weather-integratie in. Ga naar  https://pirateweather.net om een ​​API-sleutel te genereren.",

--- a/custom_components/pirateweather/translations/pl.json
+++ b/custom_components/pirateweather/translations/pl.json
@@ -21,7 +21,6 @@
                     "hourly_forecast":  "Sensory prognozy godzinowej w formie csv od 0 do 168 (np. '0,1,10'). Używane tylko wtedy, gdy wymagane są sensory.",
                     "monitored_conditions": "Monitorowane warunki do tworzenia czujników. Używane tylko wtedy, gdy wymagane są sensory.",
                     "pw_platform": "Encja Pogody i/lub Encja Sensora. Sensor będzie tworzył encjei dla każdego warunku w każdym czasie. Jeśli nie jesteś pewien, wybierz tylko Pogoda!",
-                    "pw_round": "Zaokrąglij wartości do najbliższej liczby całkowitej. Upewnij się, że wybrane jednostki pasują do jednostek systemowych.",
                     "scan_interval": "Sekundy oczekiwania między aktualizacjami. Nie zaleca się skracania tego poniżej 900 sekund (15 minut)."                                         
                 },
                 "description": "Skonfiguruj integrację Pirate Weather. Aby wygenerować klucz API, przejdź do https://pirateweather.net",

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -258,7 +258,7 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the humidity."""
         humidity = self._weather_coordinator.data.currently().d.get("humidity") * 100.0
 
-        eturn round(humidity, 0)
+        return round(humidity, 0)
 
     @property
     def native_wind_speed(self):

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -291,7 +291,7 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the visibility."""
         visibility = self._weather_coordinator.data.currently().d.get("visibility")
 
-        eturn round(visibility, 2)
+        return round(visibility, 2)
 
     @property
     def condition(self):

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -58,7 +58,6 @@ from .const import (
     PW_PLATFORMS,
     PW_PLATFORM,
     PW_PREVPLATFORM,
-    PW_ROUND,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,9 +114,6 @@ async def async_setup_platform(
 
     # Add source to config
     config_entry[PW_PLATFORM] = [PW_PLATFORMS[1]]
-
-    # Set as no rounding for compatability
-    config_entry[PW_ROUND] = "No"
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(
@@ -176,11 +172,8 @@ async def async_setup_entry(
 
     unique_id = f"{config_entry.unique_id}"
 
-    # Round Output
-    outputRound = domain_data[PW_ROUND]
-
     pw_weather = PirateWeather(
-        name, unique_id, forecast_mode, weather_coordinator, outputRound
+        name, unique_id, forecast_mode, weather_coordinator
     )
 
     async_add_entities([pw_weather], False)
@@ -205,7 +198,6 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         unique_id,
         forecast_mode: str,
         weather_coordinator: WeatherUpdateCoordinator,
-        outputRound: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(weather_coordinator)
@@ -225,8 +217,6 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         self._ds_hourly = self._weather_coordinator.data.hourly()
         self._ds_daily = self._weather_coordinator.data.daily()
 
-        self.outputRound = outputRound
-
     @property
     def unique_id(self):
         """Return a unique_id for this entity."""
@@ -234,7 +224,7 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
 
     @property
     def supported_features(self) -> WeatherEntityFeature:
-        """Determine supported features based on available data sets reported by WeatherKit."""
+        """Determine supported features based on available data sets reported by Pirate Weather."""
         features = WeatherEntityFeature(0)
 
         features |= WeatherEntityFeature.FORECAST_DAILY
@@ -261,30 +251,21 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the temperature."""
         temperature = self._weather_coordinator.data.currently().d.get("temperature")
 
-        if self.outputRound == "Yes":
-            return round(temperature, 0) + 0
-        else:
-            return round(temperature, 2)
+        return round(temperature, 2)
 
     @property
     def humidity(self):
         """Return the humidity."""
         humidity = self._weather_coordinator.data.currently().d.get("humidity") * 100.0
 
-        if self.outputRound == "Yes":
-            return round(humidity, 0) + 0
-        else:
-            return round(humidity, 2)
+        eturn round(humidity, 0)
 
     @property
     def native_wind_speed(self):
         """Return the wind speed."""
         windspeed = self._weather_coordinator.data.currently().d.get("windSpeed")
 
-        if self.outputRound == "Yes":
-            return round(windspeed, 0) + 0
-        else:
-            return round(windspeed, 2)
+        return round(windspeed, 2)
 
     @property
     def wind_bearing(self):
@@ -296,30 +277,21 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the ozone level."""
         ozone = self._weather_coordinator.data.currently().d.get("ozone")
 
-        if self.outputRound == "Yes":
-            return round(ozone, 0) + 0
-        else:
-            return round(ozone, 2)
+        return round(ozone, 2)
 
     @property
     def native_pressure(self):
         """Return the pressure."""
         pressure = self._weather_coordinator.data.currently().d.get("pressure")
 
-        if self.outputRound == "Yes":
-            return round(pressure, 0) + 0
-        else:
-            return round(pressure, 2)
+        return round(pressure, 2)
 
     @property
     def native_visibility(self):
         """Return the visibility."""
         visibility = self._weather_coordinator.data.currently().d.get("visibility")
 
-        if self.outputRound == "Yes":
-            return round(visibility, 0) + 0
-        else:
-            return round(visibility, 2)
+        eturn round(visibility, 2)
 
     @property
     def condition(self):


### PR DESCRIPTION
This PR removes the option to set rounding in the configuration option and instead sets the default rounding option on the sensors using `suggested_display_precision` . Since 2023.3 each sensor has the option to change the precision so the option to change the rounding still exists on a per-sensor basis.

This also fixes #177 by removing rounding on the weather entity as the rounding occurs before the units conversion and can lead to discrepancies between the sensors and the entity. Lint is failing on this PR because there is format changes which it can't fix because of the same issue as in #150.

I'll wait until @alexander0042 has a chance to review as I'm not sure if this is something that he would like to change. I tried to see if I could get it working with the current setup but I couldn't figure it out. Personally I found that the previous setup didn't seem to work all that well as I had some sensors which were not rounded.