### PR TITLE
Add suggested_display_precision to sensor values

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,7 +2,7 @@
 
 target-version = "py310"
 
-select = [
+lint.select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
     "C",  # complexity
@@ -26,7 +26,7 @@ select = [
     "W",  # pycodestyle
 ]
 
-ignore = [
+lint.ignore = [
     "D202",  # No blank lines allowed after function docstring
     "D203",  # 1 blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
@@ -36,7 +36,7 @@ ignore = [
     "D411",  # Missing blank line before section
     "E501",  # line too long
     "E731",  # do not assign a lambda expression, use a def
-	
+    
     # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",
     "E111",
@@ -57,11 +57,11 @@ ignore = [
     "PLE0605",
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[pyupgrade]
+[lint.pyupgrade]
 keep-runtime-typing = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -134,6 +134,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfLength.KILOMETERS,
         uk_unit=UnitOfLength.KILOMETERS,
         uk2_unit=UnitOfLength.MILES,
+        suggested_display_precision=2,
         icon="mdi:weather-lightning",
         forecast_mode=["currently"],
     ),
@@ -145,6 +146,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=DEGREE,
         uk_unit=DEGREE,
         uk2_unit=DEGREE,
+        suggested_display_precision=0,
         icon="mdi:weather-lightning",
         forecast_mode=["currently"],
     ),
@@ -162,6 +164,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk2_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+        suggested_display_precision=4,
         icon="mdi:weather-rainy",
         forecast_mode=["currently", "minutely", "hourly", "daily"],
     ),
@@ -173,6 +176,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         icon="mdi:water-percent",
         forecast_mode=["currently", "minutely", "hourly", "daily"],
     ),
@@ -185,6 +189,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfLength.CENTIMETERS,
         uk_unit=UnitOfLength.CENTIMETERS,
         uk2_unit=UnitOfLength.CENTIMETERS,
+        suggested_display_precision=4,
         icon="mdi:weather-snowy",
         forecast_mode=["hourly", "daily"],
     ),
@@ -198,6 +203,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly"],
     ),
     "apparent_temperature": PirateWeatherSensorEntityDescription(
@@ -210,6 +216,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly"],
     ),
     "dew_point": PirateWeatherSensorEntityDescription(
@@ -222,6 +229,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "wind_speed": PirateWeatherSensorEntityDescription(
@@ -233,6 +241,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
         uk_unit=UnitOfSpeed.MILES_PER_HOUR,
         uk2_unit=UnitOfSpeed.MILES_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:weather-windy",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -244,6 +253,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=DEGREE,
         uk_unit=DEGREE,
         uk2_unit=DEGREE,
+        suggested_display_precision=0,
         icon="mdi:compass",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -256,6 +266,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfSpeed.KILOMETERS_PER_HOUR,
         uk_unit=UnitOfSpeed.MILES_PER_HOUR,
         uk2_unit=UnitOfSpeed.MILES_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:weather-windy-variant",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -267,6 +278,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         icon="mdi:weather-partly-cloudy",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -280,6 +292,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=PERCENTAGE,
         uk_unit=PERCENTAGE,
         uk2_unit=PERCENTAGE,
+        suggested_display_precision=0,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "pressure": PirateWeatherSensorEntityDescription(
@@ -292,6 +305,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfPressure.MBAR,
         uk_unit=UnitOfPressure.MBAR,
         uk2_unit=UnitOfPressure.MBAR,
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "visibility": PirateWeatherSensorEntityDescription(
@@ -302,6 +316,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfLength.KILOMETERS,
         uk_unit=UnitOfLength.KILOMETERS,
         uk2_unit=UnitOfLength.MILES,
+        suggested_display_precision=2,
         icon="mdi:eye",
         forecast_mode=["currently", "hourly", "daily"],
     ),
@@ -314,6 +329,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit="DU",
         uk_unit="DU",
         uk2_unit="DU",
+        suggested_display_precision=2,
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "apparent_temperature_max": PirateWeatherSensorEntityDescription(
@@ -325,6 +341,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_high": PirateWeatherSensorEntityDescription(
@@ -336,6 +353,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_min": PirateWeatherSensorEntityDescription(
@@ -347,6 +365,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "apparent_temperature_low": PirateWeatherSensorEntityDescription(
@@ -358,6 +377,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_max": PirateWeatherSensorEntityDescription(
@@ -369,6 +389,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_high": PirateWeatherSensorEntityDescription(
@@ -380,6 +401,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_min": PirateWeatherSensorEntityDescription(
@@ -391,6 +413,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "temperature_low": PirateWeatherSensorEntityDescription(
@@ -402,6 +425,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfTemperature.CELSIUS,
         uk_unit=UnitOfTemperature.CELSIUS,
         uk2_unit=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=2,
         forecast_mode=["daily"],
     ),
     "precip_intensity_max": PirateWeatherSensorEntityDescription(
@@ -412,6 +436,7 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
         uk2_unit=UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR,
+        suggested_display_precision=2,
         icon="mdi:thermometer",
         forecast_mode=["daily"],
     ),
@@ -423,12 +448,14 @@ SENSOR_TYPES: dict[str, PirateWeatherSensorEntityDescription] = {
         ca_unit=UV_INDEX,
         uk_unit=UV_INDEX,
         uk2_unit=UV_INDEX,
+        suggested_display_precision=2,
         icon="mdi:weather-sunny",
         forecast_mode=["currently", "hourly", "daily"],
     ),
     "moon_phase": PirateWeatherSensorEntityDescription(
         key="moon_phase",
         name="Moon Phase",
+        suggested_display_precision=2,
         icon="mdi:weather-night",
         forecast_mode=["daily"],
     ),
@@ -922,10 +949,7 @@ class PirateWeatherSensor(SensorEntity):
         # Some state data needs to be rounded to whole values or converted to
         # percentages
         if self.type in ["precip_probability", "cloud_cover", "humidity"]:
-            if roundingVal == 0:
-                state = int(round(state * 100, roundingVal))
-            else:
-                state = round(state * 100, roundingVal)
+            state = state * 100
 
         # Logic to convert from SI to requsested units for compatability
         # Temps in F
@@ -1001,7 +1025,7 @@ class PirateWeatherSensor(SensorEntity):
             if roundingVal == 0:
                 outState = int(round(state, roundingVal))
             else:
-                outState = round(state, roundingVal)
+                outState = state
 
         else:
             outState = state

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -261,30 +261,21 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the temperature."""
         temperature = self._weather_coordinator.data.currently().d.get("temperature")
 
-        if self.outputRound == "Yes":
-            return round(temperature, 0) + 0
-        else:
-            return round(temperature, 2)
+        return round(temperature, 2)
 
     @property
     def humidity(self):
         """Return the humidity."""
         humidity = self._weather_coordinator.data.currently().d.get("humidity") * 100.0
 
-        if self.outputRound == "Yes":
-            return round(humidity, 0) + 0
-        else:
-            return round(humidity, 2)
+        return round(humidity, 2)
 
     @property
     def native_wind_speed(self):
         """Return the wind speed."""
         windspeed = self._weather_coordinator.data.currently().d.get("windSpeed")
 
-        if self.outputRound == "Yes":
-            return round(windspeed, 0) + 0
-        else:
-            return round(windspeed, 2)
+        return round(windspeed, 2)
 
     @property
     def wind_bearing(self):
@@ -296,30 +287,21 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Return the ozone level."""
         ozone = self._weather_coordinator.data.currently().d.get("ozone")
 
-        if self.outputRound == "Yes":
-            return round(ozone, 0) + 0
-        else:
-            return round(ozone, 2)
+        return round(ozone, 2)
 
     @property
     def native_pressure(self):
         """Return the pressure."""
         pressure = self._weather_coordinator.data.currently().d.get("pressure")
 
-        if self.outputRound == "Yes":
-            return round(pressure, 0) + 0
-        else:
-            return round(pressure, 2)
+        return round(pressure, 2)
 
     @property
     def native_visibility(self):
         """Return the visibility."""
         visibility = self._weather_coordinator.data.currently().d.get("visibility")
 
-        if self.outputRound == "Yes":
-            return round(visibility, 0) + 0
-        else:
-            return round(visibility, 2)
+        return round(visibility, 2)
 
     @property
     def condition(self):


### PR DESCRIPTION
This is a follow up to #186 which adds back the rounding option on the front-end of the card. This PR still adds in the suggested_display_precision to the sensors and also removes rounding on the entity which fixes #177

The values on the entity are rounded before being converted by HA so it can lead to discrepancies between the entity and the sensor values. if someone still needs to round the entity values you can use a weather template to achieve the same thing.

I also tried to look at #185 but I couldn't really figure much out without potentially breaking the integration.