### PR TITLE
Remove forecast option

### DIFF
--- a/custom_components/pirateweather/__init__.py
+++ b/custom_components/pirateweather/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_key = entry.data[CONF_API_KEY]
     latitude = entry.data.get(CONF_LATITUDE, hass.config.latitude)
     longitude = entry.data.get(CONF_LONGITUDE, hass.config.longitude)
-    forecast_mode = _get_config_value(entry, CONF_MODE)
+    forecast_mode = "daily"
     conditions = _get_config_value(entry, CONF_MONITORED_CONDITIONS)
     units = _get_config_value(entry, CONF_UNITS)
     forecast_days = _get_config_value(entry, CONF_FORECAST)

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -235,15 +235,6 @@ class PirateWeatherOptionsFlow(config_entries.OptionsFlow):
                         ),
                     ): cv.multi_select(PW_PLATFORMS),
                     vol.Optional(
-                        CONF_MODE,
-                        default=self.config_entry.options.get(
-                            CONF_MODE,
-                            self.config_entry.data.get(
-                                CONF_MODE, DEFAULT_FORECAST_MODE
-                            ),
-                        ),
-                    ): vol.In(FORECAST_MODES),
-                    vol.Optional(
                         CONF_LANGUAGE,
                         default=self.config_entry.options.get(
                             CONF_LANGUAGE,

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -26,7 +26,6 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    FORECAST_MODES,
     LANGUAGES,
     CONF_UNITS,
     DEFAULT_UNITS,
@@ -72,9 +71,6 @@ class PirateWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
                 vol.Required(PW_PLATFORM, default=[PW_PLATFORMS[1]]): cv.multi_select(
                     PW_PLATFORMS
-                ),
-                vol.Required(CONF_MODE, default=DEFAULT_FORECAST_MODE): vol.In(
-                    FORECAST_MODES
                 ),
                 vol.Required(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
                     LANGUAGES


### PR DESCRIPTION
This PR removes the option to select the forecast mode as it no longer does anything as of the V1.3 update and fixes #185

There's a pre-release version of this PR available and I haven't come across any issues so far during testing.