### PR TITLE
Fix Rounding

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: "Lint"
 on:
   push:
   pull_request:
+  
+permissions:
+  contents: write
 
 jobs:
   ruff:

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -1030,7 +1030,7 @@ class PirateWeatherSensor(SensorEntity):
             else:
                 outState = round(state, roundingVal)
                 
-        if self.type in [
+        elif self.type in [
             "precip_accumulation",
             "precip_intensity",
             "precip_intensity_max",

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -1029,13 +1029,13 @@ class PirateWeatherSensor(SensorEntity):
                 outState = int(round(state, roundingVal))
             else:
                 outState = round(state, roundingVal)
-                
+
         elif self.type in [
             "precip_accumulation",
             "precip_intensity",
             "precip_intensity_max",
         ]:
-           outState = round(state, roundingPrecip)
+            outState = round(state, roundingPrecip)
 
         else:
             outState = state

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -943,13 +943,15 @@ class PirateWeatherSensor(SensorEntity):
         # If output rounding is requested, round to nearest integer
         if self.outputRound == "Yes":
             roundingVal = 0
+            roundingPrecip = 2
         else:
-            roundingVal = 1
+            roundingVal = 2
+            roundingPrecip = 4
 
         # Some state data needs to be rounded to whole values or converted to
         # percentages
         if self.type in ["precip_probability", "cloud_cover", "humidity"]:
-            state = state * 100
+            state = int(state * 100)
 
         # Logic to convert from SI to requsested units for compatability
         # Temps in F
@@ -963,7 +965,7 @@ class PirateWeatherSensor(SensorEntity):
                 "apparent_temperature_high",
                 "apparent_temperature_low",
             ]:
-                state = (state * 9 / 5) + 32
+                state = round(state * 9 / 5) + 32
 
         # Precipitation Accumilation (mm in SI) to inches
         if self.requestUnits in ["us"]:
@@ -1015,17 +1017,25 @@ class PirateWeatherSensor(SensorEntity):
             "apparent_temperature_high",
             "temperature_max",
             "apparent_temperature_max",
-            "precip_accumulation",
             "pressure",
             "ozone",
             "uvIndex",
             "wind_speed",
             "wind_gust",
+            "visibility",
+            "nearest_storm_distance",
         ]:
             if roundingVal == 0:
                 outState = int(round(state, roundingVal))
             else:
-                outState = state
+                outState = round(state, roundingVal)
+                
+        if self.type in [
+            "precip_accumulation",
+            "precip_intensity",
+            "precip_intensity_max",
+        ]:
+           outState = round(state, roundingPrecip)
 
         else:
             outState = state

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -1019,7 +1019,7 @@ class PirateWeatherSensor(SensorEntity):
             "apparent_temperature_max",
             "pressure",
             "ozone",
-            "uvIndex",
+            "uv_index",
             "wind_speed",
             "wind_gust",
             "visibility",


### PR DESCRIPTION
This PR adds back in the rounding to sensors as per #192 since `suggested_display_precision` isn't supported by all cards. I  added rounding to the sensors which weren't included before. Also updated it so that precipitation sensors have 4 decimal places by default and with rounding enabled 2 decimal places.

The Lint workflow is failing because it's trying to commit formatting changes but can't. Due to the same issue that the GitHub issues are failing #150.