### PR TITLE
bug: "Pirate Weather data update for" to print in DEBUG, not INFO

### DIFF
--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -45,7 +45,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         async with async_timeout.timeout(60):
             try:
                 data = await self._get_pw_weather()
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Pirate Weather data update for "
                     + str(self.latitude)
                     + ","


### PR DESCRIPTION
"Pirate Weather data update for" to print in DEBUG, not INFO

Reducing log printouts