### PR TITLE
Remove auto as an allowed unit

### DIFF
--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -822,7 +822,7 @@ LANGUAGE_CODES = [
     "zh-tw",
 ]
 
-ALLOWED_UNITS = ["auto", "si", "us", "ca", "uk", "uk2"]
+ALLOWED_UNITS = ["si", "us", "ca", "uk", "uk2"]
 
 ALERTS_ATTRS = ["time", "description", "expires", "severity", "uri", "regions", "title"]
 

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -69,7 +69,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(PW_PLATFORM): cv.string,
         vol.Optional(PW_PREVPLATFORM): cv.string,
         vol.Optional(CONF_MODE, default="hourly"): vol.In(FORECAST_MODES),
-        vol.Optional(CONF_UNITS): vol.In(["auto", "si", "us", "ca", "uk", "uk2"]),
+        vol.Optional(CONF_UNITS): vol.In(["si", "us", "ca", "uk", "uk2"]),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
     }


### PR DESCRIPTION
Noticed the other day that "auto" is still specified as a valid unit even though its not supported in the API. It wasn't selectable in the config flow but I removed the instances of "auto" units in the code.