### PR TITLE
Use shared HA sessions and declare integration type

### DIFF
--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
-import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import (
@@ -24,6 +23,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from httpx import HTTPError
 
 from .const import (
@@ -319,8 +319,6 @@ class PirateWeatherOptionsFlow(OptionsFlow):
 async def _is_pw_api_online(hass, api_key, lat, lon, endpoint):
     forecastString = endpoint + "/forecast/" + api_key + "/" + str(lat) + "," + str(lon)
 
-    async with (
-        aiohttp.ClientSession(raise_for_status=False) as session,
-        session.get(forecastString) as resp,
-    ):
+    session = async_get_clientsession(hass)
+    async with session.get(forecastString) as resp:
         return resp.status

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from httpx import HTTPError
 
 from .const import (
     ALL_CONDITIONS,

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+from aiohttp import ClientError
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import (
@@ -141,7 +142,7 @@ class PirateWeatherConfigFlow(ConfigFlow, domain=DOMAIN):
                         "Invalid API Key, Ensure that you've subscribed to API at https://pirate-weather.apiable.io/"
                     )
 
-            except HTTPError:
+            except ClientError:
                 _LOGGER.warning(
                     "Pirate Weather Setup Error: API HTTP Error: %s", api_status
                 )

--- a/custom_components/pirateweather/config_flow.py
+++ b/custom_components/pirateweather/config_flow.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
-from aiohttp import ClientError
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,

--- a/custom_components/pirateweather/manifest.json
+++ b/custom_components/pirateweather/manifest.json
@@ -10,5 +10,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alexander0042/pirate-weather-ha/issues",
-  "version": "1.7.4"
+  "version": "1.7.5"
 }

--- a/custom_components/pirateweather/manifest.json
+++ b/custom_components/pirateweather/manifest.json
@@ -7,8 +7,8 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/alexander0042/pirate-weather-ha",
-  "iot_class": "cloud_polling",
   "integration_type": "service",
+  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alexander0042/pirate-weather-ha/issues",
   "version": "1.7.4"
 }

--- a/custom_components/pirateweather/manifest.json
+++ b/custom_components/pirateweather/manifest.json
@@ -8,6 +8,7 @@
   "dependencies": [],
   "documentation": "https://github.com/alexander0042/pirate-weather-ha",
   "iot_class": "cloud_polling",
+  "integration_type": "service",
   "issue_tracker": "https://github.com/alexander0042/pirate-weather-ha/issues",
   "version": "1.7.4"
 }

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -1,9 +1,9 @@
 """Weather data coordinator for the Pirate Weather service."""
 
-from aiohttp import ClientError
 import logging
 
 import async_timeout
+from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -4,9 +4,9 @@ import json
 import logging
 from http.client import HTTPException
 
-import aiohttp
 import async_timeout
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -95,10 +95,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             + self.language
         )
 
-        async with (
-            aiohttp.ClientSession(raise_for_status=True) as session,
-            session.get(forecastString) as resp,
-        ):
+        session = async_get_clientsession(self.hass)
+        async with session.get(forecastString) as resp:
             resptext = await resp.text()
             jsonText = json.loads(resptext)
             headers = resp.headers

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -1,9 +1,9 @@
 """Weather data coordinator for the Pirate Weather service."""
 
-import json
 import logging
 from http.client import HTTPException
 
+from aiohttp import ClientError
 import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -62,7 +62,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         async with async_timeout.timeout(60):
             try:
                 data = await self._get_pw_weather()
-            except HTTPException as err:
+            except ClientError as err:
                 raise UpdateFailed(f"Error communicating with API: {err}") from err
         return data
 

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -97,11 +97,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
         session = async_get_clientsession(self.hass)
         async with session.get(forecastString) as resp:
+            resp.raise_for_status()
             resptext = await resp.text()
             jsonText = json.loads(resptext)
             headers = resp.headers
-            status = resp.raise_for_status()
-
             _LOGGER.debug("Pirate Weather data update from: %s", self.endpoint)
-
-            return Forecast(jsonText, status, headers)
+            return Forecast(jsonText, resp, headers)

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -1,9 +1,8 @@
 """Weather data coordinator for the Pirate Weather service."""
 
-import logging
-from http.client import HTTPException
-
 from aiohttp import ClientError
+import logging
+
 import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -98,8 +98,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         session = async_get_clientsession(self.hass)
         async with session.get(forecastString) as resp:
             resp.raise_for_status()
-            resptext = await resp.text()
-            jsonText = json.loads(resptext)
+            jsonText = await resp.json()
             headers = resp.headers
             _LOGGER.debug("Pirate Weather data update from: %s", self.endpoint)
             return Forecast(jsonText, resp, headers)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
-homeassistant==2025.7.4
+homeassistant==2025.8.0
 pip>=21.0,<25.3
 ruff==0.12.7


### PR DESCRIPTION
## Summary
- use Home Assistant's shared HTTP client instead of new `aiohttp` sessions
- mark the integration as a service via `integration_type`
- update Home Assistant dev dependency to 2025.8.0

## Testing
- `scripts/lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f0beb644832d99577244ac5e304b