### PR TITLE
Request Pirate Weather API in preferred units

### DIFF
--- a/custom_components/pirateweather/__init__.py
+++ b/custom_components/pirateweather/__init__.py
@@ -114,6 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         longitude,
         timedelta(seconds=scan_interval),
         language,
+        units,
         endpoint,
         hass,
         entry,

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -1205,64 +1205,6 @@ class PirateWeatherSensor(SensorEntity):
         if self.type in ["precip_probability", "cloud_cover", "humidity"]:
             state = int(state * 100)
 
-        # Logic to convert from SI to requsested units for compatability
-        # Temps in F
-        if self.requestUnits in ["us"]:
-            if self.type in [
-                "dew_point",
-                "temperature",
-                "apparent_temperature",
-                "temperature_high",
-                "temperature_low",
-                "apparent_temperature_high",
-                "apparent_temperature_low",
-            ]:
-                state = round(state * 9 / 5) + 32
-
-        # Precipitation Accumulation (cm in SI) to inches
-        if self.requestUnits in ["us"]:
-            if self.type in [
-                "precip_accumulation",
-                "liquid_accumulation",
-                "snow_accumulation",
-                "ice_accumulation",
-                "current_day_liquid",
-                "current_day_snow",
-                "current_day_ice",
-            ]:
-                state = state * 0.3937008
-
-        # Precipitation Intensity (mm/h in SI) to inches
-        if self.requestUnits in ["us"]:
-            if self.type in [
-                "precip_intensity",
-            ]:
-                state = state * 0.0393701
-
-        # Km to Miles
-        if self.requestUnits in ["us", "uk", "uk2"]:
-            if self.type in [
-                "visibility",
-                "nearest_storm_distance",
-            ]:
-                state = state * 0.621371
-
-        # Meters/second to Miles/hour
-        if self.requestUnits in ["us", "uk", "uk2"]:
-            if self.type in [
-                "wind_speed",
-                "wind_gust",
-            ]:
-                state = state * 2.23694
-
-        # Meters/second to Km/ hour
-        if self.requestUnits in ["ca"]:
-            if self.type in [
-                "wind_speed",
-                "wind_gust",
-            ]:
-                state = state * 3.6
-
         # Convert unix times to datetimes times
         if self.type in [
             "temperature_high_time",

--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -28,6 +28,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         longitude,
         scan_interval,
         language,
+        units,
         endpoint,
         hass,
         config_entry: ConfigEntry,
@@ -38,8 +39,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         self.longitude = longitude
         self.scan_interval = scan_interval
         self.language = language
+        self.requested_units = units
         self.endpoint = endpoint
-        self.requested_units = "si"
 
         self.data = None
         self.currently = None


### PR DESCRIPTION
## Summary
- request forecasts using the configured unit system
- drop sensor-level unit conversions
- align weather entity units with API responses

## Testing
- `ruff check custom_components/pirateweather/weather_update_coordinator.py custom_components/pirateweather/__init__.py custom_components/pirateweather/sensor.py custom_components/pirateweather/weather.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a125f5ee4832d86a6bacba7398746