### PR TITLE
Update models for API version 2.8 support

### DIFF
--- a/custom_components/pirateweather/forecast_models.py
+++ b/custom_components/pirateweather/forecast_models.py
@@ -99,8 +99,8 @@ class PirateWeatherDataBlock(UnicodeMixin):
     def __init__(self, d=None):
         """Initialize the data block with summary and icon information."""
         d = d or {}
-        self.summary = d.get("summary", None)
-        self.icon = d.get("icon", None)
+        self.summary = d.get("summary")
+        self.icon = d.get("icon")
         self.data = [
             PirateWeatherDataPoint(datapoint) for datapoint in d.get("data", [])
         ]
@@ -186,4 +186,3 @@ class Alert(UnicodeMixin):
     def __unicode__(self):
         """Return a string representation of the alert."""
         return f"<Alert instance: {self.title} at {self.time}>"
-        


### PR DESCRIPTION
Adds the updated models with support for API version 2.8. Also @alexander0042 I can remove the future block? We're sticking with this library right?