### PR TITLE
chore: bump homeassistant 2026.2.2?2026.2.3, ruff 0.15.1?0.15.2, pytest-homeassistant-custom-component 0.13.315?0.13.316

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.10.1
-homeassistant==2026.2.2
+homeassistant==2026.2.3
 pip>=21.0,<26.1
-ruff==0.15.1
+ruff==0.15.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 pytest>=9.0.0
-pytest-homeassistant-custom-component==0.13.315
+pytest-homeassistant-custom-component==0.13.316
 pytest-asyncio==1.3.0


### PR DESCRIPTION
Three patch-version bumps to keep the test environment current.

`pytest-homeassistant-custom-component==0.13.316` (released 2026-02-21) hard-pins `homeassistant==2026.2.3` as a transitive requirement, so the two bumps in `requirements.txt` and `requirements_test.txt` move together. The `homeassistant` package itself went from 2026.2.2 to 2026.2.3 (released 2026-02-20), a standard patch release. `ruff` moved from 0.15.1 to 0.15.2 (released 2026-02-19), a patch release with formatter and linter bug fixes and no new rules.

Steps taken to verify:

1. Confirmed `pytest-homeassistant-custom-component 0.13.316` via `https://pypi.org/pypi/pytest-homeassistant-custom-component/0.13.316/json` - `requires_dist` includes `homeassistant==2026.2.3`, confirming the HA pin must move with it.
2. Confirmed `homeassistant 2026.2.3` and `ruff 0.15.2` are the current stable patch releases via `https://pypi.org/pypi/{package}/json`.
3. All three are strictly backward-compatible patch bumps; no API changes require code modifications.