### PR TITLE
Fix longitude getting Home Assistant location latitude

### DIFF
--- a/custom_components/pirateweather/weather_update_coordinator.py
+++ b/custom_components/pirateweather/weather_update_coordinator.py
@@ -77,7 +77,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             requestLatitude = self.latitude
 
         if self.longitude == 0.0:
-            requestLongitude = self.hass.config.latitude
+            requestLongitude = self.hass.config.longitude
         else:
             requestLongitude = self.longitude
 


### PR DESCRIPTION
Fix minor issue where when using 0 as longitude it was getting the Home Assistant location latitude not longitude.