### PR TITLE
Add Pirate Weather service device

### DIFF
--- a/custom_components/pirateweather/__init__.py
+++ b/custom_components/pirateweather/__init__.py
@@ -18,6 +18,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import (
     CONF_ENDPOINT,
@@ -28,6 +30,7 @@ from .const import (
     DOMAIN,
     ENTRY_NAME,
     ENTRY_WEATHER_COORDINATOR,
+    MANUFACTURER,
     PLATFORMS,
     PW_PLATFORM,
     PW_PLATFORMS,
@@ -145,6 +148,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_ENDPOINT: endpoint,
         CONF_MODELS: models,
     }
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        entry_type=DeviceEntryType.SERVICE,
+        identifiers={(DOMAIN, entry.unique_id or entry.entry_id)},
+        manufacturer=MANUFACTURER,
+        name=name,
+    )
 
     # Setup platforms
     # If both platforms

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -1140,12 +1140,12 @@ class PirateWeatherSensor(SensorEntity):
 
         self._attr_unique_id = unique_id
         self._attr_name = name
-        self._attr_device_info = {
-            "entry_type": DeviceEntryType.SERVICE,
-            "identifiers": {(DOMAIN, service_id)},
-            "manufacturer": MANUFACTURER,
-            "name": name,
-        }
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, service_id)},
+            manufacturer=MANUFACTURER,
+            name=name,
+        )
 
         self.forecast_day = forecast_day
         self.forecast_hour = forecast_hour

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -35,7 +35,7 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType, StateType
 from homeassistant.util import dt as dt_util

--- a/custom_components/pirateweather/sensor.py
+++ b/custom_components/pirateweather/sensor.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType, StateType
 from homeassistant.util import dt as dt_util
@@ -44,6 +45,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     ENTRY_WEATHER_COORDINATOR,
+    MANUFACTURER,
     PW_PLATFORM,
     PW_PLATFORMS,
     PW_PREVPLATFORM,
@@ -1029,6 +1031,7 @@ async def async_setup_entry(
     conditions = domain_data[CONF_MONITORED_CONDITIONS]
     forecast_days = domain_data[CONF_FORECAST]
     forecast_hours = domain_data[CONF_HOURLY_FORECAST]
+    service_id = config_entry.unique_id or config_entry.entry_id
 
     # Round Output
     outputRound = domain_data[PW_ROUND]
@@ -1060,6 +1063,7 @@ async def async_setup_entry(
                     description=sensorDescription,
                     requestUnits=requestUnits,
                     outputRound=outputRound,
+                    service_id=service_id,
                 )
             )
 
@@ -1079,6 +1083,7 @@ async def async_setup_entry(
                         description=sensorDescription,
                         requestUnits=requestUnits,
                         outputRound=outputRound,
+                        service_id=service_id,
                     )
                 )
 
@@ -1098,6 +1103,7 @@ async def async_setup_entry(
                         description=sensorDescription,
                         requestUnits=requestUnits,
                         outputRound=outputRound,
+                        service_id=service_id,
                     )
                 )
 
@@ -1122,6 +1128,7 @@ class PirateWeatherSensor(SensorEntity):
         description: PirateWeatherSensorEntityDescription,
         requestUnits: str,
         outputRound: str,
+        service_id: str,
     ) -> None:
         """Initialize the sensor."""
         self.client_name = name
@@ -1133,13 +1140,12 @@ class PirateWeatherSensor(SensorEntity):
 
         self._attr_unique_id = unique_id
         self._attr_name = name
-
-        # self._attr_device_info = DeviceInfo(
-        #    entry_type=DeviceEntryType.SERVICE,
-        #    identifiers={(DOMAIN, unique_id)},
-        #    manufacturer=MANUFACTURER,
-        #    name=DEFAULT_NAME,
-        # )
+        self._attr_device_info = {
+            "entry_type": DeviceEntryType.SERVICE,
+            "identifiers": {(DOMAIN, service_id)},
+            "manufacturer": MANUFACTURER,
+            "name": name,
+        }
 
         self.forecast_day = forecast_day
         self.forecast_hour = forecast_hour

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -300,12 +300,12 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         """Initialize the sensor."""
         super().__init__(weather_coordinator)
         self._attr_name = name
-        self._attr_device_info = {
-            "entry_type": DeviceEntryType.SERVICE,
-            "identifiers": {(DOMAIN, service_id)},
-            "manufacturer": MANUFACTURER,
-            "name": name,
-        }
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, service_id)},
+            manufacturer=MANUFACTURER,
+            name=name,
+        )
         self._weather_coordinator = weather_coordinator
         self._name = name
         self._mode = forecast_mode

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.dt import utc_from_timestamp
@@ -50,6 +51,7 @@ from .const import (
     DOMAIN,
     ENTRY_WEATHER_COORDINATOR,
     FORECAST_MODES,
+    MANUFACTURER,
     PW_PLATFORM,
     PW_PLATFORMS,
     PW_PREVPLATFORM,
@@ -262,12 +264,13 @@ async def async_setup_entry(
     forecast_mode = domain_data[CONF_MODE]
 
     unique_id = f"{config_entry.unique_id}"
+    service_id = config_entry.unique_id or config_entry.entry_id
 
     # Round Output
     outputRound = domain_data[PW_ROUND]
 
     pw_weather = PirateWeather(
-        name, unique_id, forecast_mode, weather_coordinator, outputRound
+        name, unique_id, forecast_mode, weather_coordinator, outputRound, service_id
     )
 
     async_add_entities([pw_weather], False)
@@ -292,10 +295,17 @@ class PirateWeather(SingleCoordinatorWeatherEntity[WeatherUpdateCoordinator]):
         forecast_mode: str,
         weather_coordinator: WeatherUpdateCoordinator,
         outputRound: str,
+        service_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(weather_coordinator)
         self._attr_name = name
+        self._attr_device_info = {
+            "entry_type": DeviceEntryType.SERVICE,
+            "identifiers": {(DOMAIN, service_id)},
+            "manufacturer": MANUFACTURER,
+            "name": name,
+        }
         self._weather_coordinator = weather_coordinator
         self._name = name
         self._mode = forecast_mode

--- a/custom_components/pirateweather/weather.py
+++ b/custom_components/pirateweather/weather.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.dt import utc_from_timestamp

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, Mock, patch
 from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from custom_components.pirateweather.const import DOMAIN
 
@@ -25,6 +27,14 @@ async def test_setup_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert DOMAIN in hass.data
     assert mock_config_entry.entry_id in hass.data[DOMAIN]
+
+    device_registry = dr.async_get(hass)
+    service_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "test_unique_id")}
+    )
+    assert service_device is not None
+    assert service_device.entry_type is DeviceEntryType.SERVICE
+    assert service_device.manufacturer == "PirateWeather"
 
 
 async def test_unload_entry(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pirateweather.const import (
@@ -64,6 +66,13 @@ async def test_sensor_setup(
 
     assert temp_sensor is not None
     assert humidity_sensor is not None
+
+    device_registry = dr.async_get(hass)
+    service_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "test_sensor_unique_id")}
+    )
+    assert service_device is not None
+    assert service_device.entry_type is DeviceEntryType.SERVICE
 
 
 async def test_sensor_values(


### PR DESCRIPTION
Re Issue #475.
Took way too long to get to this, but finally switched to classifying Pirate Weather as a service to allow the devices to be grouped, cleaning up the UI considerably!