### PR TITLE
Update Home Assistant version to 2026.7.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Pirate Weather",
     "render_readme": true,
-    "homeassistant": "2024.12.0"
+    "homeassistant": "2026.7.0"
 }


### PR DESCRIPTION
The change to using UnitOfDensity from CONCENTRATION_MICROGRAMS_PER_CUBIC_METER requires HA 2026.7 as it did not exist before then. Bump the required HA version to 2026.7 to prevent outdated installations from updating to an incompatible version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Home Assistant version to 2026.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->